### PR TITLE
docs: add install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ antora を試しに動かしてみてるリポジトリです。
 ビルドは、下記コマンドでビルドされます。
 
 ```bash
+pnpm install
 pnpm build
 ```
 


### PR DESCRIPTION
## Summary
- add instruction to run `pnpm install` before `pnpm build` in README

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684944871748832fb79694f003c7edf2